### PR TITLE
Make LICENSE detection failure an error

### DIFF
--- a/commit_protos.bash
+++ b/commit_protos.bash
@@ -38,8 +38,8 @@ for pd in $package_dirs; do
         license_file=$(dirname $pd)/LICENSE
     fi
     if ! [ -f $license_file ] ; then
-	echo NO license file at $license_file either, continuing
-	continue
+	echo NO license file at $license_file either aborting
+	exit -2
     fi
     package=$(basename $pd)
     result_dir=results/${ROS_DISTRO}/${package}/


### PR DESCRIPTION
Abort on missing LICENSE file

The last ones are being triaged in #8