### PR TITLE
Explicitly allow workflow write permissions to the repo contents

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -1,5 +1,8 @@
 name: Update Protos
 
+permissions:
+  contents: write
+
 on:
   workflow_dispatch:
   schedule:


### PR DESCRIPTION
From https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions

I've removed the permissions globally which broke the deployment with #12 