### PR TITLE
Workaround missing dependency on console_bridge_vendor

### DIFF
--- a/build_protos.bash
+++ b/build_protos.bash
@@ -5,7 +5,7 @@
 set -e
 set -x
 
-TARGET_PACKAGES="common_interfaces control_msgs pcl_msgs"
+TARGET_PACKAGES="common_interfaces control_msgs pcl_msgs console_bridge_vendor"
 
 echo ROS_DISTRO: ${ROS_DISTRO:?is_unset}
 


### PR DESCRIPTION
I believe that tf2 has an undeclared dependency breaking the build.